### PR TITLE
Set runner's information to the output much earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v1.0.0
+        uses: machulav/ec2-github-runner@v1.0.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v1.0.0
+        uses: machulav/ec2-github-runner@v1.0.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - do-the-job # required to wait when the main job is done
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,9 @@ async function start() {
   const label = config.generateUniqueLabel();
   const githubRegistrationToken = await gh.getRegistrationToken();
   const ec2InstanceId = await aws.startEc2Instance(label, githubRegistrationToken);
+  setOutput(label, ec2InstanceId);
   await aws.waitForInstanceRunning(ec2InstanceId);
   await gh.waitForRunnerCreated(label);
-  setOutput(label, ec2InstanceId);
 }
 
 async function stop() {


### PR DESCRIPTION
When the GitHub Action workflow is canceled during the execution of the "Start self-hosted EC2 runner" job, the final job, "Stop self-hosted EC2 runner" failed as the input was provided only at the end of the first job. Though, the EC2 runner data available already in the first seconds of the first job execution. The rest of the time, the script waits for the runner to be registered as a self-hosted runner in GitHub actions.

These changes make the output available earlier, right after the EC2 runner data is available. In this way, the EC2 runner can be properly terminated even if the GitHub Actions workflow is canceled during the execution of the "Start self-hosted EC2 runner" job.

Related to issue #7 
