### PR TITLE
Increase retry interval, add quiet period, add info logging

### DIFF
--- a/src/gh.js
+++ b/src/gh.js
@@ -53,8 +53,13 @@ async function removeRunner() {
 
 async function waitForRunnerCreated(label) {
   const timeoutMinutes = 5;
-  const retryIntervalSeconds = 1;
+  const retryIntervalSeconds = 10;
+  const quietPeriodSeconds = 30;
   let waitSeconds = 0;
+
+  core.info(`Waiting ${quietPeriodSeconds} seconds before polling for runner.`);
+  await new Promise(r => setTimeout(r, quietPeriodSeconds * 1000));
+  core.info(`Beginning to poll for runner every ${retryIntervalSeconds}`);
 
   return new Promise((resolve, reject) => {
     const interval = setInterval(async () => {
@@ -72,6 +77,7 @@ async function waitForRunnerCreated(label) {
         resolve();
       } else {
         waitSeconds += retryIntervalSeconds;
+        core.info('Waiting...');
       }
     }, retryIntervalSeconds * 1000);
   });

--- a/src/gh.js
+++ b/src/gh.js
@@ -57,9 +57,9 @@ async function waitForRunnerCreated(label) {
   const quietPeriodSeconds = 30;
   let waitSeconds = 0;
 
-  core.info(`Waiting ${quietPeriodSeconds} seconds before polling for runner.`);
+  core.info(`Waiting ${quietPeriodSeconds}s before polling for runner`);
   await new Promise(r => setTimeout(r, quietPeriodSeconds * 1000));
-  core.info(`Beginning to poll for runner every ${retryIntervalSeconds}`);
+  core.info(`Polling for runner every ${retryIntervalSeconds}s`);
 
   return new Promise((resolve, reject) => {
     const interval = setInterval(async () => {


### PR DESCRIPTION
Closes https://github.com/machulav/ec2-github-runner/issues/27

In my runs I am seeing about 1 minute between instanceStarted and runner registered, so I implemented just a short quiet period of 30s, and made the time delay 10s. This could be further tuned, or exposed as config parameters to let people tune it to their use case.