### PR TITLE
Properly paginate runner lists call.

### DIFF
--- a/src/gh.js
+++ b/src/gh.js
@@ -9,8 +9,8 @@ async function getRunner(label) {
   const octokit = github.getOctokit(config.input.githubToken);
 
   try {
-    const response = await octokit.request('GET /repos/{owner}/{repo}/actions/runners', config.githubContext);
-    const foundRunners = _.filter(response.data.runners, { labels: [{ name: label }] });
+    const runners = await octokit.paginate('GET /repos/{owner}/{repo}/actions/runners', config.githubContext);
+    const foundRunners = _.filter(runners, { labels: [{ name: label }] });
     return foundRunners.length > 0 ? foundRunners[0] : null;
   } catch (error) {
     return null;


### PR DESCRIPTION
Use the octokit [paginate](https://octokit.github.io/rest.js/v18#pagination) to properly paginate the list call. This fixes #46.