### PR TITLE
Support trying multiple subnets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,8 @@ inputs:
     required: false
   subnet-id:
     description: >-
-      VPC Subnet Id. The subnet should belong to the same VPC as the specified security group.
+      VPC Subnet Id. You may provide a comma-separated list of subnet ids to try multiple subnets.
+      The subnet should belong to the same VPC as the specified security group.
       This input is required if you use the 'start' mode.
     required: false
   security-group-id:

--- a/src/aws.js
+++ b/src/aws.js
@@ -35,27 +35,32 @@ async function startEc2Instance(label, githubRegistrationToken) {
 
   const userData = buildUserDataScript(githubRegistrationToken, label);
 
-  const params = {
-    ImageId: config.input.ec2ImageId,
-    InstanceType: config.input.ec2InstanceType,
-    MinCount: 1,
-    MaxCount: 1,
-    UserData: Buffer.from(userData.join('\n')).toString('base64'),
-    SubnetId: config.input.subnetId,
-    SecurityGroupIds: [config.input.securityGroupId],
-    IamInstanceProfile: { Name: config.input.iamRoleName },
-    TagSpecifications: config.tagSpecifications,
-  };
+  const subnetId = config.input.subnetId;
+  const subnets = subnetId ? subnetId.replace(/\s/g, '').split(',') : [null];
 
-  try {
-    const result = await ec2.runInstances(params).promise();
-    const ec2InstanceId = result.Instances[0].InstanceId;
-    core.info(`AWS EC2 instance ${ec2InstanceId} is started`);
-    return ec2InstanceId;
-  } catch (error) {
-    core.error('AWS EC2 instance starting error');
-    throw error;
+  for (const subnet of subnets) {
+    const params = {
+      ImageId: config.input.ec2ImageId,
+      InstanceType: config.input.ec2InstanceType,
+      MinCount: 1,
+      MaxCount: 1,
+      UserData: Buffer.from(userData.join('\n')).toString('base64'),
+      SubnetId: subnet,
+      SecurityGroupIds: [config.input.securityGroupId],
+      IamInstanceProfile: { Name: config.input.iamRoleName },
+      TagSpecifications: config.tagSpecifications,
+    };
+    try {
+      const result = await ec2.runInstances(params).promise();
+      const ec2InstanceId = result.Instances[0].InstanceId;
+      core.info(`AWS EC2 instance ${ec2InstanceId} is started`);
+      return ec2InstanceId;
+    } catch (error) {
+      core.warning('AWS EC2 instance starting error');
+      core.warning(error);
+    }
   }
+  core.setFailed(`Failed to launch instance after trying in ${subnets.length} subnets.`);
 }
 
 async function terminateEc2Instance() {


### PR DESCRIPTION
When AWS is unable to provide an instance in a given availability zone, this action can fail repeatedly (if the condition preventing AWS from having available instances persists). This happens particularly with gpu instance types. 

By adding support for multiple subnet ids as input, we can configure the action to try multiple subnets and hence availability zones, giving us a better chance of finding a zone with available instances.