### PR TITLE
Disable Instance MetaData Service v1

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -40,6 +40,7 @@ async function startEc2Instance(label, githubRegistrationToken) {
     InstanceType: config.input.ec2InstanceType,
     MinCount: 1,
     MaxCount: 1,
+    MetadataOptions: { HttpTokens: 'required' },
     UserData: Buffer.from(userData.join('\n')).toString('base64'),
     SubnetId: config.input.subnetId,
     SecurityGroupIds: [config.input.securityGroupId],


### PR DESCRIPTION
Disabling the Instance MetaData Service v1 improves security and is required for some compliance requirements.
As far as I could tell, the only thing that is using the IMDS would be cloud-init in the actual instance, which fully supports IMDS v2.