### PR TITLE
fix(gh): do not swallow error retrieving GitHub runners

### DIFF
--- a/src/gh.js
+++ b/src/gh.js
@@ -13,6 +13,7 @@ async function getRunner(label) {
     const foundRunners = _.filter(runners, { labels: [{ name: label }] });
     return foundRunners.length > 0 ? foundRunners[0] : null;
   } catch (error) {
+    core.error(`Error retrieving GitHub runners: ${error}`);
     return null;
   }
 }
@@ -58,7 +59,7 @@ async function waitForRunnerRegistered(label) {
   let waitSeconds = 0;
 
   core.info(`Waiting ${quietPeriodSeconds}s for the AWS EC2 instance to be registered in GitHub as a new self-hosted runner`);
-  await new Promise(r => setTimeout(r, quietPeriodSeconds * 1000));
+  await new Promise((r) => setTimeout(r, quietPeriodSeconds * 1000));
   core.info(`Checking every ${retryIntervalSeconds}s if the GitHub self-hosted runner is registered`);
 
   return new Promise((resolve, reject) => {
@@ -68,7 +69,9 @@ async function waitForRunnerRegistered(label) {
       if (waitSeconds > timeoutMinutes * 60) {
         core.error('GitHub self-hosted runner registration error');
         clearInterval(interval);
-        reject(`A timeout of ${timeoutMinutes} minutes is exceeded. Your AWS EC2 instance was not able to register itself in GitHub as a new self-hosted runner.`);
+        reject(
+          `A timeout of ${timeoutMinutes} minutes is exceeded. Your AWS EC2 instance was not able to register itself in GitHub as a new self-hosted runner.`
+        );
       }
 
       if (runner && runner.status === 'online') {


### PR DESCRIPTION
Adds error logging when the call to retrieve GitHub runners fails.  In my case this was happening due to a token permissions issue.

(There's one prettier formatting fix included as well.

Fixes:
https://github.com/machulav/ec2-github-runner/issues/119