### PR TITLE
Add 'pre-runner-script' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Use the following steps to prepare your workflow for running on your EC2 self-ho
 4. Create a new EC2 image (AMI) from the instance.
 5. Remove the instance if not required anymore after the image is created.
 
+Alternatively, you can use a vanilla EC2 AMI and set up the dependencies via `pre-runner-script` in the workflow YAML file. See example in the `pre-runner-script` documentation below.
+
 **4. Prepare VPC with subnet and security group**
 
 1. Create a new VPC and a new subnet in it.
@@ -203,6 +205,8 @@ Now you're ready to go!
 | `iam-role-name`                                                                                                                                                              | Optional. Used only with the `start` mode. | IAM role name to attach to the created EC2 runner. <br><br> This allows the runner to have permissions to run additional actions within the AWS account, without having to manage additional GitHub secrets and AWS users. <br><br> Setting this requires additional AWS permissions for the role launching the instance (see above). |
 | `aws-resource-tags`                                                                                                                                                          | Optional. Used only with the `start` mode. | Specifies tags to add to the EC2 instance and any attached storage. <br><br> This field is a stringified JSON array of tag objects, each containing a `Key` and `Value` field (see example below). <br><br> Setting this requires additional AWS permissions for the role launching the instance (see above).                         |
 | `runner-home-dir`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies a directory where pre-installed actions-runner software and scripts are located.<br><br> |
+| `pre-runner-script`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies bash commands to run before the runner starts.  It's useful for installing dependencies with apt-get, yum, dnf, etc. For example:<pre>          - name: Start EC2 runner<br>            with:<br>              mode: start<br>              ...<br>              pre-runner-script: \|<br>                 sudo yum update -y && \ <br>                 sudo yum install docker git libicu -y<br>                 sudo systemctl enable docker</pre>
+<br><br> |
 
 ### Environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,11 @@ inputs:
     description: >-
       Directory that contains actions-runner software and scripts. E.g. /home/runner/actions-runner.
     required: false
+  pre-runner-script:
+    description: >-
+      Specifies bash commands to run before the runner starts. It's useful for installing dependencies with apt-get, yum, dnf, etc.
+    required: false
+
 outputs:
   label:
     description: >-

--- a/src/aws.js
+++ b/src/aws.js
@@ -10,6 +10,8 @@ function buildUserDataScript(githubRegistrationToken, label) {
     return [
       '#!/bin/bash',
       `cd "${config.input.runnerHomeDir}"`,
+      `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
+      'source pre-runner-script.sh',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
       './run.sh',
@@ -18,6 +20,8 @@ function buildUserDataScript(githubRegistrationToken, label) {
     return [
       '#!/bin/bash',
       'mkdir actions-runner && cd actions-runner',
+      `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
+      'source pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
       'curl -O -L https://github.com/actions/runner/releases/download/v2.299.1/actions-runner-linux-${RUNNER_ARCH}-2.299.1.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.299.1.tar.gz',

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ class Config {
       ec2InstanceId: core.getInput('ec2-instance-id'),
       iamRoleName: core.getInput('iam-role-name'),
       runnerHomeDir: core.getInput('runner-home-dir'),
+      preRunnerScript: core.getInput('pre-runner-script'),
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));


### PR DESCRIPTION
Add a `pre-runner-script` option to specify arbitrary bash commands to run before the runner starts up on the instance.  This is useful if you need to install dependencies or have OS-specific setup steps.  For example:
```yaml
          - name: Start EC2 runner
            with:
              mode: start
              ec2-image-id: ami-07bdb09c49774f92e
              pre-runner-script: |
                 sudo yum update -y && \
                 sudo yum install docker git libicu -y && \
                 sudo systemctl enable docker
```
