### PR TITLE
Add 'key-name' and 'block-device-mapping' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ Now you're ready to go!
 | `aws-resource-tags`                                                                                                                                                          | Optional. Used only with the `start` mode. | Specifies tags to add to the EC2 instance and any attached storage. <br><br> This field is a stringified JSON array of tag objects, each containing a `Key` and `Value` field (see example below). <br><br> Setting this requires additional AWS permissions for the role launching the instance (see above).                         |
 | `runner-home-dir`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies a directory where pre-installed actions-runner software and scripts are located.<br><br> |
 | `pre-runner-script`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies bash commands to run before the runner starts.  It's useful for installing dependencies with apt-get, yum, dnf, etc. For example:<pre>          - name: Start EC2 runner<br>            with:<br>              mode: start<br>              ...<br>              pre-runner-script: \|<br>                 sudo yum update -y && \ <br>                 sudo yum install docker git libicu -y<br>                 sudo systemctl enable docker</pre>
-<br><br> |
+`key-name`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies SSH key-pair name to assign to an instance.  This is useful for SSHing into an instance for debugging.<br><br> |
+| `block-device-mapping`                                                                                                                                                              | Optional. Used only with the `start` mode. | JSON string specifying the [BlockDeviceMapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html).  For example:<pre> block-device-mapper: \|<br>   [<br>   {"DeviceName" : "/dev/sda1", "Ebs" : { "VolumeType": "gp2", "VolumeSize": 34 }},<br>   {"DeviceName" : "/dev/sdb", "VirtualName": "ephemeral0" }<br>   ]
+</pre>|
 
 ### Environment variables
 
@@ -262,6 +264,12 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
+          key-name: my-ssh-key # optional
+          block-device-mapper: | # optional
+            [
+            {"DeviceName" : "/dev/sda1", "Ebs" : { "VolumeType": "gp2", "VolumeSize": 34 }},
+            {"DeviceName" : "/dev/sdb", "VirtualName": "ephemeral0" }
             ]
   do-the-job:
     name: Do the job on the runner

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,15 @@ inputs:
     description: >-
       Specifies bash commands to run before the runner starts. It's useful for installing dependencies with apt-get, yum, dnf, etc.
     required: false
+  block-device-mapping:
+    description: >-
+      JSON string of EC2 BlockDeviceMapping (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html).
+    required: false
+    default: '[]'
+  key-name:
+    description: >-
+      Assign SSH key-pair name to an instance.  This can be useful for SSHing into an instance for debugging.
+    required: false
 
 outputs:
   label:

--- a/src/aws.js
+++ b/src/aws.js
@@ -47,6 +47,8 @@ async function startEc2Instance(label, githubRegistrationToken) {
     SecurityGroupIds: [config.input.securityGroupId],
     IamInstanceProfile: { Name: config.input.iamRoleName },
     TagSpecifications: config.tagSpecifications,
+    BlockDeviceMappings: config.input.blockDeviceMappings,
+    KeyName: config.input.keyName,
   };
 
   try {

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,8 @@ class Config {
       iamRoleName: core.getInput('iam-role-name'),
       runnerHomeDir: core.getInput('runner-home-dir'),
       preRunnerScript: core.getInput('pre-runner-script'),
+      blockDeviceMappings: JSON.parse(core.getInput('block-device-mapping')),
+      keyName: core.getInput('key-name'),
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));


### PR DESCRIPTION
Add two new options to workflow file:

`key-name`: Specifies SSH key-pair name to assign to an instance.  This is useful for SSHing into an instance for debugging.

`block-device-mapping`: JSON string specifying the BlockDeviceMapping for an instance.