### PR TITLE
Use the label input, if there is one.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ function setOutput(label, ec2InstanceId) {
 }
 
 async function start() {
-  const label = config.generateUniqueLabel();
+  const label = config.input.label ? config.input.label : config.input.generateUniqueLabel();
   const githubRegistrationToken = await gh.getRegistrationToken();
   const ec2InstanceId = await aws.startEc2Instance(label, githubRegistrationToken);
   setOutput(label, ec2InstanceId);


### PR DESCRIPTION
It looks like labels are always autogenerated, ignoring input.

This PR tries to use the workflow input `label`, if empty, then generate.