### PR TITLE
add new block-device-mappings parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Now you're ready to go!
 | `runner-home-dir`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies a directory where pre-installed actions-runner software and scripts are located.<br><br> |
 | `pre-runner-script`                                                                                                                                                              | Optional. Used only with the `start` mode. | Specifies bash commands to run before the runner starts.  It's useful for installing dependencies with apt-get, yum, dnf, etc. For example:<pre>          - name: Start EC2 runner<br>            with:<br>              mode: start<br>              ...<br>              pre-runner-script: \|<br>                 sudo yum update -y && \ <br>                 sudo yum install docker git libicu -y<br>                 sudo systemctl enable docker</pre> |
 | `market-type` | Optional. Used only with the `start` mode. | The only valid option is `spot`. If `spot` is specified, a Spot instance will be requested. If left unspecified, an on-demand instance will be provisioned. |
+| `block-device-mappings` | Optional. Used only with the `start` mode. | JSON string specifying the block device mappings for the EC2 instance. For example: <br> <pre>[{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 100, "VolumeType": "gp3"}}]</pre> See <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html">AWS BlockDeviceMapping docs</a> for all options. |
 | `startup-quiet-period-seconds` | Optional | Default: 30 |
 | `startup-retry-interval-seconds` | Optional | Default: 10 |
 | `startup-timeout-minutes` | Optional | Default: 5 | 
@@ -275,6 +276,10 @@ jobs:
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
+          block-device-mappings: > # optional, to customize EBS volumes
+            [
+              {"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 100, "VolumeType": "gp3"}}
             ]
   do-the-job:
     name: Do the job on the runner

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,11 @@ inputs:
       Specifies the market (purchasing) option for the instance:
           - 'spot' - Use a spot instance
     required: false
+  block-device-mappings:
+    description: >-
+      JSON string specifying the block device mappings for the EC2 instance.
+      Example: '[{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 100, "VolumeType": "gp3"}}]'
+    required: false
   startup-quiet-period-seconds:
     description: >-
       Specifies the quiet period in seconds after the instance starts.

--- a/src/aws.js
+++ b/src/aws.js
@@ -75,6 +75,10 @@ async function startEc2Instance(label, githubRegistrationToken) {
     InstanceMarketOptions: buildMarketOptions(),
   };
 
+  if (config.input.blockDeviceMappings.length > 0) {
+    params.BlockDeviceMappings = config.input.blockDeviceMappings;
+  }
+
   try {
     const result = await ec2.send(new RunInstancesCommand(params));
     const ec2InstanceId = result.Instances[0].InstanceId;

--- a/src/config.js
+++ b/src/config.js
@@ -20,7 +20,8 @@ class Config {
       startupTimeoutMinutes: core.getInput('startup-timeout-minutes'),
       subnetId: core.getInput('subnet-id'),
       runAsService: core.getInput('run-runner-as-service') === 'true',
-      runAsUser: core.getInput('run-runner-as-user')
+      runAsUser: core.getInput('run-runner-as-user'),
+      blockDeviceMappings: JSON.parse(core.getInput('block-device-mappings') || '[]')
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));


### PR DESCRIPTION
This allows the user to specify the settings on the node's underlying EBS volume.

For example, the user can change the thoroughput on the volume.