### PR TITLE
Retry allocation in multiple zones/regions if there is no capacity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,6 +102,7 @@ inputs:
     description: >-
       Specifies the timeout in minutes to register the runner after the quiet period.
     required: false
+    default: '5'
   run-runner-as-service:
     description: >-
       Start the runner as a service rather than using ./run.sh as root.

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,9 @@ inputs:
     description: >-
       JSON string array of objects with configurations for multiple availability zones.
       Each object should contain 'imageId', 'subnetId', and 'securityGroupId'.
-      Example: '[{"imageId":"ami-123","subnetId":"subnet-123","securityGroupId":"sg-123"},{"imageId":"ami-456","subnetId":"subnet-456","securityGroupId":"sg-456"}]'
+      Optionally, you can specify 'region' to launch the instance in a specific AWS region.
+      If 'region' is not specified, the default AWS_REGION environment variable will be used.
+      Example: '[{"imageId":"ami-123","subnetId":"subnet-123","securityGroupId":"sg-123"},{"imageId":"ami-456","subnetId":"subnet-456","securityGroupId":"sg-456","region":"us-west-2"}]'
       When provided, the action will try each configuration in sequence until a successful instance is launched.
       This takes precedence over individual ec2-image-id, subnet-id, and security-group-id parameters.
     required: false
@@ -136,6 +138,10 @@ outputs:
     description: >-
       EC2 Instance Id of the created runner.
       The id is used to terminate the EC2 instance when the runner is not needed anymore.
+  region:
+    description: >-
+      AWS region where the EC2 instance was created.
+      This is useful for subsequent AWS operations on the instance.
 runs:
   using: node20
   main: ./dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,18 @@ inputs:
     description: >-
       GitHub Personal Access Token with the 'repo' scope assigned.
     required: true
+  availability-zones-config:
+    description: >-
+      JSON string array of objects with configurations for multiple availability zones.
+      Each object should contain 'imageId', 'subnetId', and 'securityGroupId'.
+      Example: '[{"imageId":"ami-123","subnetId":"subnet-123","securityGroupId":"sg-123"},{"imageId":"ami-456","subnetId":"subnet-456","securityGroupId":"sg-456"}]'
+      When provided, the action will try each configuration in sequence until a successful instance is launched.
+      This takes precedence over individual ec2-image-id, subnet-id, and security-group-id parameters.
+    required: false
   ec2-image-id:
     description: >-
       EC2 Image Id (AMI). The new runner will be launched from this image.
-      This input is required if you use the 'start' mode.
+      This input is required if you use the 'start' mode and don't provide availability-zones-config.
     required: false
   ec2-instance-type:
     description: >-
@@ -28,14 +36,14 @@ inputs:
   subnet-id:
     description: >-
       VPC Subnet Id. The subnet should belong to the same VPC as the specified security group.
-      This input is required if you use the 'start' mode.
+      This input is required if you use the 'start' mode and don't provide availability-zones-config.
     required: false
   security-group-id:
     description: >-
       EC2 Security Group Id.
       The security group should belong to the same VPC as the specified subnet.
       The runner doesn't require any inbound traffic. However, outbound traffic should be allowed.
-      This input is required if you use the 'start' mode.
+      This input is required if you use the 'start' mode and don't provide availability-zones-config.
     required: false
   label:
     description: >-
@@ -88,17 +96,19 @@ inputs:
     description: >-
       Specifies the retry interval in seconds to register the runner after the quiet period.
     required: false
-  startup-timeout-seconds:
+  startup-timeout-minutes:
     description: >-
-      Specifies the timeout in seconds to register the runner after the quiet period.
+      Specifies the timeout in minutes to register the runner after the quiet period.
+    required: false
   run-runner-as-service:
-    type: boolean
     description: >-
       Start the runner as a service rather than using ./run.sh as root.
     required: false
+    default: 'false'
   run-runner-as-user:
     description: >-
       Specify user under whom the runner service should run
+    required: false
   ec2-volume-size:
     description: >-
       EC2 volume size in GB.

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,9 @@ class Config {
       availabilityZonesConfig: core.getInput('availability-zones-config'),
     };
 
+    // Get the AWS_REGION environment variable
+    this.defaultRegion = process.env.AWS_REGION;
+    
     const tags = JSON.parse(core.getInput('aws-resource-tags'));
     this.tagSpecifications = null;
     if (tags.length > 0) {
@@ -81,6 +84,10 @@ class Config {
             if (!az.securityGroupId) {
               throw new Error(`Missing securityGroupId in availability-zones-config at index ${index}`);
             }
+            // Region is optional, will use the default if not specified
+            if (!az.region) {
+              az.region = this.defaultRegion;
+            }
           });
         } catch (error) {
           throw new Error(`Failed to parse availability-zones-config: ${error.message}`);
@@ -104,7 +111,9 @@ class Config {
         this.availabilityZones.push({
           imageId: this.input.ec2ImageId,
           subnetId: this.input.subnetId,
-          securityGroupId: this.input.securityGroupId
+          securityGroupId: this.input.securityGroupId,
+          // Add default region when using legacy configuration
+          region: this.defaultRegion
         });
         
         core.info('Using individual parameters as a single availability zone configuration');

--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,8 @@ class Config {
       ec2VolumeSize: core.getInput('ec2-volume-size'),
       ec2DeviceName: core.getInput('ec2-device-name'),
       ec2VolumeType: core.getInput('ec2-volume-type'),
-      blockDeviceMappings: JSON.parse(core.getInput('block-device-mappings') || '[]')
+      blockDeviceMappings: JSON.parse(core.getInput('block-device-mappings') || '[]'),
+      availabilityZonesConfig: core.getInput('availability-zones-config'),
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));
@@ -56,9 +57,57 @@ class Config {
       throw new Error(`The 'github-token' input is not specified`);
     }
 
+    // Initialize availabilityZones as an empty array
+    this.availabilityZones = [];
+
     if (this.input.mode === 'start') {
-      if (!this.input.ec2ImageId || !this.input.ec2InstanceType || !this.input.subnetId || !this.input.securityGroupId) {
-        throw new Error(`Not all the required inputs are provided for the 'start' mode`);
+      // Parse availability zones config if provided
+      if (this.input.availabilityZonesConfig) {
+        try {
+          this.availabilityZones = JSON.parse(this.input.availabilityZonesConfig);
+          
+          // Validate each availability zone configuration
+          if (!Array.isArray(this.availabilityZones)) {
+            throw new Error('availability-zones-config must be a JSON array');
+          }
+          
+          this.availabilityZones.forEach((az, index) => {
+            if (!az.imageId) {
+              throw new Error(`Missing imageId in availability-zones-config at index ${index}`);
+            }
+            if (!az.subnetId) {
+              throw new Error(`Missing subnetId in availability-zones-config at index ${index}`);
+            }
+            if (!az.securityGroupId) {
+              throw new Error(`Missing securityGroupId in availability-zones-config at index ${index}`);
+            }
+          });
+        } catch (error) {
+          throw new Error(`Failed to parse availability-zones-config: ${error.message}`);
+        }
+      }
+
+      // Check for required instance type regardless of config method
+      if (!this.input.ec2InstanceType) {
+        throw new Error(`The 'ec2-instance-type' input is required for the 'start' mode.`);
+      }
+
+      // If no availability zones config provided, check for individual parameters
+      if (this.availabilityZones.length === 0) {
+        if (!this.input.ec2ImageId || !this.input.subnetId || !this.input.securityGroupId) {
+          throw new Error(
+            `Either provide 'availability-zones-config' or all of the following: 'ec2-image-id', 'subnet-id', 'security-group-id'`
+          );
+        }
+        
+        // Convert individual parameters to a single availability zone config
+        this.availabilityZones.push({
+          imageId: this.input.ec2ImageId,
+          subnetId: this.input.subnetId,
+          securityGroupId: this.input.securityGroupId
+        });
+        
+        core.info('Using individual parameters as a single availability zone configuration');
       }
 
       if (this.marketType?.length > 0 && this.input.marketType !== 'spot') {

--- a/src/config.js
+++ b/src/config.js
@@ -123,8 +123,11 @@ class Config {
         throw new Error('Invalid `market-type` input. Allowed values: spot.');
       }
     } else if (this.input.mode === 'stop') {
-      if (!this.input.label || !this.input.ec2InstanceId) {
-        throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
+      if (!this.input.ec2InstanceId) {
+        throw new Error(`The 'ec2-instance-id' input is required for the 'stop' mode.`);
+      }
+      if (!this.input.label) {
+        core.warning(`The 'label' input is not specified for the 'stop' mode. The runner will be removed by the 'ec2-instance-id' input.`);
       }
     } else {
       throw new Error('Wrong mode. Allowed values: start, stop.');

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,24 @@ const gh = require('./gh');
 const config = require('./config');
 const core = require('@actions/core');
 
-function setOutput(label, ec2InstanceId) {
+function setOutput(label, ec2InstanceId, region) {
   core.setOutput('label', label);
   core.setOutput('ec2-instance-id', ec2InstanceId);
+  core.setOutput('region', region);
 }
 
 async function start() {
   const label = config.input.label ? config.input.label : config.generateUniqueLabel();
   const githubRegistrationToken = await gh.getRegistrationToken();
-  const ec2InstanceId = await aws.startEc2Instance(label, githubRegistrationToken);
-  setOutput(label, ec2InstanceId);
-  await aws.waitForInstanceRunning(ec2InstanceId);
+  const result = await aws.startEc2Instance(label, githubRegistrationToken);
+  const ec2InstanceId = result.ec2InstanceId;
+  const region = result.region;
+  
+  // Set outputs
+  setOutput(label, ec2InstanceId, region);
+  
+  // Wait for the instance to be running
+  await aws.waitForInstanceRunning(ec2InstanceId, region);
   await gh.waitForRunnerRegistered(label);
 }
 


### PR DESCRIPTION
When using spot instances, sometimes an availability zone does not have sufficient capacity, and the action fails.

This PR adds the ability for users to specify a list of objects in `availability-zones-config` specifying fields for image ID, subnet ID, securityGroupID, and region. The action traverses those in sequence until it finds a region with the instance.

It then returns the instance ID and region, so the stop workflow can work on the correct region (the user gets credentials there).

This has been used successfully in the unvariance collector's [wrapper action](https://github.com/unvariance/collector/tree/main/.github/actions/aws-runner) used in a [benchmarking workflow](https://github.com/unvariance/collector/blob/main/.github/workflows/benchmark.yaml) and increased the reliability of the workflow significantly.