### PR TITLE
remove default ec2VolumeSize or ec2VolumeType settings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,6 @@ inputs:
   ec2-volume-size:
     description: >-
       EC2 volume size in GB.
-    default: "8"
     required: false
   ec2-device-name:
     description: >-
@@ -112,7 +111,6 @@ inputs:
   ec2-volume-type:
     description: >-
       EC2 block device type.
-    default: gp2
     required: false
 
 outputs:

--- a/src/aws.js
+++ b/src/aws.js
@@ -73,16 +73,19 @@ async function startEc2Instance(label, githubRegistrationToken) {
     IamInstanceProfile: { Name: config.input.iamRoleName },
     TagSpecifications: config.tagSpecifications,
     InstanceMarketOptions: buildMarketOptions(),
-    BlockDeviceMappings: [
+  };
+
+  if (config.input.ec2VolumeSize !== '' || config.input.ec2VolumeType !== '') {
+    params.BlockDeviceMappings = [
       {
         DeviceName: config.input.ec2DeviceName,
         Ebs: {
-          VolumeSize: config.input.ec2VolumeSize,
-          VolumeType: config.input.ec2VolumeType,
+          ...(config.input.ec2VolumeSize !== '' && { VolumeSize: config.input.ec2VolumeSize }),
+          ...(config.input.ec2VolumeType !== '' && { VolumeType: config.input.ec2VolumeType }),
         },
       },
-    ],
-  };
+    ];
+  }
 
   if (config.input.blockDeviceMappings.length > 0) {
     params.BlockDeviceMappings = config.input.blockDeviceMappings;


### PR DESCRIPTION
Prior to this change, if a user did not specify `ec2-volume-size` or `ec2-volume-type`, we would send default values of `8` and `gp2` to the EC2 API.

This was a problem if the user's AMI used a snapshot with other settings (like a bigger disk size, or another disk type like `io1`). AWS could fail to start the nodes if the AMI was incompatible with these defaults.

Update the action to only send `ec2VolumeSize` or `ec2VolumeType` in the API call if the user has specified a value (not an empty string).

With this change, we reintroduce the behavior prior to 8b37f736c69ba6af391e437447d3c07548478d78.

This change preserves the default for `ec2-device-name`, since we need that default value in order to construct `BlockDeviceSettings`.

Fixes: #234 