### PR TITLE
feat!: add packages input that installs packages on the AWS instance as part of cloud-init

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,6 +125,12 @@ inputs:
     description: >-
       EC2 block device type.
     required: false
+  packages:
+    description: >-
+      JSON array of packages to install via cloud-init.
+      Example: '["git", "docker.io", "nodejs"]'
+    required: false
+    default: '[]'
 
 outputs:
   label:

--- a/src/aws.js
+++ b/src/aws.js
@@ -110,8 +110,6 @@ async function createEc2InstanceWithParams(imageId, subnetId, securityGroupId, l
   const ec2 = new EC2Client(ec2ClientOptions);
 
   const userData = buildUserDataScript(githubRegistrationToken, label);
-  core.info('User data contents:');
-  core.info(userData);
 
   const params = {
     ImageId: imageId,

--- a/src/aws.js
+++ b/src/aws.js
@@ -27,7 +27,7 @@ function buildRunCommands(githubRegistrationToken, label) {
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
       `latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')`,
       'latest_version=$(echo ${latest_version_label:1})',
-      'curl -O -L https://github.com/actions/runner/releases/download/${latest_version}/actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
+      'curl -O -L https://github.com/actions/runner/releases/download/${latest_version_label}/actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,

--- a/src/aws.js
+++ b/src/aws.js
@@ -13,8 +13,7 @@ function buildRunCommands(githubRegistrationToken, label) {
       '#!/bin/bash',
       'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
       `cd "${config.input.runnerHomeDir}"`,
-      `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
-      'source pre-runner-script.sh',
+      'source /tmp/pre-runner-script.sh',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     ];
@@ -23,8 +22,7 @@ function buildRunCommands(githubRegistrationToken, label) {
       '#!/bin/bash',
       'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
       'mkdir actions-runner && cd actions-runner',
-      `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
-      'source pre-runner-script.sh',
+      'source /tmp/pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
       'curl -O -L https://github.com/actions/runner/releases/download/v2.313.0/actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
@@ -62,8 +60,21 @@ function buildUserDataScript(githubRegistrationToken, label) {
     });
   }
   
-  // Write the script file
+  // Write files
   yamlContent += 'write_files:\n';
+  
+  // Write pre-runner script if specified
+  if (config.input.preRunnerScript) {
+    yamlContent += '  - path: /tmp/pre-runner-script.sh\n';
+    yamlContent += '    permissions: "0755"\n';
+    yamlContent += '    content: |\n';
+    
+    config.input.preRunnerScript.split('\n').forEach(line => {
+      yamlContent += `      ${line}\n`;
+    });
+  }
+  
+  // Write main setup script
   yamlContent += '  - path: /tmp/runner-setup.sh\n';
   yamlContent += '    permissions: "0755"\n';
   yamlContent += '    content: |\n';

--- a/src/aws.js
+++ b/src/aws.js
@@ -48,6 +48,9 @@ function buildRunCommands(githubRegistrationToken, label) {
 function buildUserDataScript(githubRegistrationToken, label) {
   const runCommands = buildRunCommands(githubRegistrationToken, label);
   
+  // Create a script file with all commands to avoid YAML escaping issues
+  const scriptContent = runCommands.join('\n');
+  
   // Start with cloud-init header
   let yamlContent = '#cloud-config\n';
   
@@ -59,11 +62,20 @@ function buildUserDataScript(githubRegistrationToken, label) {
     });
   }
   
-  // Add run commands
-  yamlContent += 'runcmd:\n';
-  runCommands.forEach(cmd => {
-    yamlContent += `  - ${cmd}\n`;
+  // Write the script file
+  yamlContent += 'write_files:\n';
+  yamlContent += '  - path: /tmp/runner-setup.sh\n';
+  yamlContent += '    permissions: "0755"\n';
+  yamlContent += '    content: |\n';
+  
+  // Add each line of the script with proper indentation
+  scriptContent.split('\n').forEach(line => {
+    yamlContent += `      ${line}\n`;
   });
+  
+  // Execute the script
+  yamlContent += 'runcmd:\n';
+  yamlContent += '  - /tmp/runner-setup.sh\n';
   
   return yamlContent;
 }

--- a/src/aws.js
+++ b/src/aws.js
@@ -21,13 +21,15 @@ function buildRunCommands(githubRegistrationToken, label) {
     // latest version recipe under MIT license from https://github.com/actions/runner/blob/main/scripts/create-latest-svc.sh
     userData = [
       '#!/bin/bash',
-      'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
+      // 'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
       'mkdir actions-runner && cd actions-runner',
       'source /tmp/pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
       `latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')`,
       'latest_version=$(echo ${latest_version_label:1})',
-      'curl -O -L https://github.com/actions/runner/releases/download/${latest_version_label}/actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
+      'fetch_url="https://github.com/actions/runner/releases/download/${latest_version_label}/actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz"',
+      'echo "Fetching runner from ${fetch_url}"',
+      'curl -O -L ${fetch_url}',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
@@ -115,6 +117,8 @@ async function createEc2InstanceWithParams(imageId, subnetId, securityGroupId, l
   const ec2 = new EC2Client(ec2ClientOptions);
 
   const userData = buildUserDataScript(githubRegistrationToken, label);
+  core.info('User data contents:');
+  core.info(userData);
 
   const params = {
     ImageId: imageId,

--- a/src/aws.js
+++ b/src/aws.js
@@ -18,14 +18,17 @@ function buildRunCommands(githubRegistrationToken, label) {
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     ];
   } else {
+    // latest version recipe under MIT license from https://github.com/actions/runner/blob/main/scripts/create-latest-svc.sh
     userData = [
       '#!/bin/bash',
       'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
       'mkdir actions-runner && cd actions-runner',
       'source /tmp/pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-      'curl -O -L https://github.com/actions/runner/releases/download/v2.313.0/actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
-      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
+      `latest_version_label=$(curl -s -X GET 'https://api.github.com/repos/actions/runner/releases/latest' | jq -r '.tag_name')`,
+      'latest_version=$(echo ${latest_version_label:1})',
+      'curl -O -L https://github.com/actions/runner/releases/download/${latest_version}/actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
+      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${latest_version}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     ];

--- a/src/aws.js
+++ b/src/aws.js
@@ -87,6 +87,8 @@ async function createEc2InstanceWithParams(imageId, subnetId, securityGroupId, l
   const ec2 = new EC2Client(ec2ClientOptions);
 
   const userData = buildUserDataScript(githubRegistrationToken, label);
+  core.info('User data contents:');
+  core.info(userData);
 
   const params = {
     ImageId: imageId,

--- a/src/aws.js
+++ b/src/aws.js
@@ -3,8 +3,8 @@ const { EC2Client, RunInstancesCommand, TerminateInstancesCommand, waitUntilInst
 const core = require('@actions/core');
 const config = require('./config');
 
-// User data scripts are run as the root user
-function buildUserDataScript(githubRegistrationToken, label) {
+// Build the commands to run on the instance
+function buildRunCommands(githubRegistrationToken, label) {
   let userData;
   if (config.input.runnerHomeDir) {
     // If runner home directory is specified, we expect the actions-runner software (and dependencies)
@@ -44,6 +44,30 @@ function buildUserDataScript(githubRegistrationToken, label) {
   return userData;
 }
 
+// Build cloud-init YAML user data
+function buildUserDataScript(githubRegistrationToken, label) {
+  const runCommands = buildRunCommands(githubRegistrationToken, label);
+  
+  // Start with cloud-init header
+  let yamlContent = '#cloud-config\n';
+  
+  // Add packages if specified
+  if (config.input.packages && config.input.packages.length > 0) {
+    yamlContent += 'packages:\n';
+    config.input.packages.forEach(pkg => {
+      yamlContent += `  - ${pkg}\n`;
+    });
+  }
+  
+  // Add run commands
+  yamlContent += 'runcmd:\n';
+  runCommands.forEach(cmd => {
+    yamlContent += `  - ${cmd}\n`;
+  });
+  
+  return yamlContent;
+}
+
 function buildMarketOptions() {
   if (config.input.marketType !== 'spot') {
     return undefined;
@@ -71,7 +95,7 @@ async function createEc2InstanceWithParams(imageId, subnetId, securityGroupId, l
     MinCount: 1,
     SecurityGroupIds: [securityGroupId],
     SubnetId: subnetId,
-    UserData: Buffer.from(userData.join('\n')).toString('base64'),
+    UserData: Buffer.from(userData).toString('base64'),
     IamInstanceProfile: config.input.iamRoleName ? { Name: config.input.iamRoleName } : undefined,
     TagSpecifications: config.tagSpecifications,
     InstanceMarketOptions: buildMarketOptions(),

--- a/src/aws.js
+++ b/src/aws.js
@@ -63,15 +63,17 @@ function buildUserDataScript(githubRegistrationToken, label) {
   // Write files
   yamlContent += 'write_files:\n';
   
-  // Write pre-runner script if specified
+  // Always write pre-runner script (even if empty) since runner-setup.sh always sources it
+  yamlContent += '  - path: /tmp/pre-runner-script.sh\n';
+  yamlContent += '    permissions: "0755"\n';
+  yamlContent += '    content: |\n';
+  
   if (config.input.preRunnerScript) {
-    yamlContent += '  - path: /tmp/pre-runner-script.sh\n';
-    yamlContent += '    permissions: "0755"\n';
-    yamlContent += '    content: |\n';
-    
     config.input.preRunnerScript.split('\n').forEach(line => {
       yamlContent += `      ${line}\n`;
     });
+  } else {
+    yamlContent += '      #!/bin/bash\n';
   }
   
   // Write main setup script

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ class Config {
       ec2VolumeType: core.getInput('ec2-volume-type'),
       blockDeviceMappings: JSON.parse(core.getInput('block-device-mappings') || '[]'),
       availabilityZonesConfig: core.getInput('availability-zones-config'),
+      packages: JSON.parse(core.getInput('packages') || '[]'),
     };
 
     // Get the AWS_REGION environment variable


### PR DESCRIPTION
Installing packages in the `pre-runner-script` has been unreliable as it seems during boot there are other processes locking the package index. It appears the recommended way is to use the `packages` property of cloud-init.

This requires passing a cloud init YAML (starts with `#cloud-config`) as user data. Luckily this format is supported by AWS. 

This PR:
- writes the `pre-runner-script.sh` and the main user-data script (`runner-setup.sh`) using cloud-init's `write_files`
- adds a cloud-init `packages` directive to install packages
- runs the main script using cloud-init's `runcmd`

This allows supporting multi-line pre-runner-script.sh. As a bonus, this greatly simplified strange escaping issues stemming from `echo "${config.input.preRunnerScript}" > pre-runner-script.sh` -- we tried to write a file inside the pre-runner-script which required multiple levels of nested escaping before this change, now this burden is greatly reduced.