### PR TITLE
Add support for EC2 metadata options input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,10 @@ inputs:
     description: >-
       EC2 block device type.
     required: false
-
+  metadata-options:
+    description: >-
+      JSON string specifying the metadata options for the EC2 instance.
+      Example: '{"HttpTokens": "required", "HttpEndpoint": "enabled", "HttpPutResponseHopLimit": 2, "InstanceMetadataTags": "enabled"}'
 outputs:
   label:
     description: >-

--- a/src/aws.js
+++ b/src/aws.js
@@ -75,6 +75,7 @@ async function createEc2InstanceWithParams(imageId, subnetId, securityGroupId, l
     IamInstanceProfile: config.input.iamRoleName ? { Name: config.input.iamRoleName } : undefined,
     TagSpecifications: config.tagSpecifications,
     InstanceMarketOptions: buildMarketOptions(),
+    MetadataOptions: Object.keys(config.input.metadataOptions).length > 0 ? config.input.metadataOptions : undefined,
   };
 
   if (config.input.ec2VolumeSize !== '' || config.input.ec2VolumeType !== '') {

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ class Config {
       ec2VolumeType: core.getInput('ec2-volume-type'),
       blockDeviceMappings: JSON.parse(core.getInput('block-device-mappings') || '[]'),
       availabilityZonesConfig: core.getInput('availability-zones-config'),
+      metadataOptions: JSON.parse(core.getInput('metadata-options') || '{}'),
     };
 
     // Get the AWS_REGION environment variable


### PR DESCRIPTION
Introduces a new 'metadata-options' input in action.yml and updates config.js and aws.js to handle and pass EC2 instance metadata options when creating instances. This allows users to specify advanced metadata settings for their EC2 instances.