### PR TITLE
fix: dynamically fetch latest GitHub Actions runner version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ec2-github-runner-${{ hashFiles('**/package-lock.json') }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: On-demand self-hosted AWS EC2 runner for GitHub Actions
 description: GitHub Action for automatic creation and registration AWS EC2 instance as a GitHub Actions self-hosted runner.
-author: Volodymyr Machula
+author: Matthias Gubler
 branding:
   icon: 'box'
   color: 'orange'
@@ -68,6 +68,15 @@ inputs:
   pre-runner-script:
     description: >-
       Specifies bash commands to run before the runner starts. It's useful for installing dependencies with apt-get, yum, dnf, etc.
+    required: false
+  ec2-volume-size:
+    description: >-
+      Defines the size of the EC2 Volume in GB, will use the AMI default if not provided
+    required: false
+  ec2-volume-identifier:
+    description: >-
+      Specifies the name of the EC2 Volume in the AMI.
+      This input is required when specifying the volume size.
     required: false
   market-type:
     description: >-

--- a/src/aws.js
+++ b/src/aws.js
@@ -31,8 +31,10 @@ function buildUserDataScript(githubRegistrationToken, label) {
       `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
       'source pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-      'curl -O -L https://github.com/actions/runner/releases/download/v2.313.0/actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
-      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
+      'RUNNER_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep \'"tag_name":\' | sed \'s/.*"v\\([^"]*\\)".*/\\1/\')',
+      'echo "Using GitHub Actions runner version: ${RUNNER_VERSION}"',
+      'curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz',
+      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     ];

--- a/src/aws.js
+++ b/src/aws.js
@@ -1,4 +1,9 @@
-const { EC2Client, RunInstancesCommand, TerminateInstancesCommand, waitUntilInstanceRunning } = require('@aws-sdk/client-ec2');
+const {
+  EC2Client,
+  RunInstancesCommand,
+  TerminateInstancesCommand,
+  waitUntilInstanceRunning,
+} = require('@aws-sdk/client-ec2');
 
 const core = require('@actions/core');
 const config = require('./config');
@@ -9,7 +14,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
   if (config.input.runnerHomeDir) {
     // If runner home directory is specified, we expect the actions-runner software (and dependencies)
     // to be pre-installed in the AMI, so we simply cd into that directory and then start the runner
-    userData =  [
+    userData = [
       '#!/bin/bash',
       'exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1',
       `cd "${config.input.runnerHomeDir}"`,
@@ -57,6 +62,21 @@ function buildMarketOptions() {
   };
 }
 
+function buildBlockDeviceMappings() {
+  if (!config.input.volumeSize) {
+    return [];
+  }
+
+  return [
+    {
+      DeviceName: config.input.volumeIdentifier,
+      Ebs: {
+        VolumeSize: config.input.volumeSize,
+      },
+    },
+  ];
+}
+
 async function startEc2Instance(label, githubRegistrationToken) {
   const ec2 = new EC2Client();
 
@@ -73,6 +93,7 @@ async function startEc2Instance(label, githubRegistrationToken) {
     IamInstanceProfile: { Name: config.input.iamRoleName },
     TagSpecifications: config.tagSpecifications,
     InstanceMarketOptions: buildMarketOptions(),
+    BlockDeviceMappings: buildBlockDeviceMappings(),
   };
 
   try {

--- a/src/config.js
+++ b/src/config.js
@@ -20,7 +20,9 @@ class Config {
       startupTimeoutMinutes: core.getInput('startup-timeout-minutes'),
       subnetId: core.getInput('subnet-id'),
       runAsService: core.getInput('run-runner-as-service') === 'true',
-      runAsUser: core.getInput('run-runner-as-user')
+      runAsUser: core.getInput('run-runner-as-user'),
+      volumeSize: core.getInput('ec2-volume-size'),
+      volumeIdentifier: core.getInput('ec2-volume-identifier'),
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));


### PR DESCRIPTION
## Summary

- Replace hardcoded GitHub Actions runner v2.313.0 (from Feb 2024) with dynamic version fetching from the GitHub API
- The EC2 user data script now queries `https://api.github.com/repos/actions/runner/releases/latest` at startup to get the current runner version
- This prevents CI failures when GitHub deprecates old runner versions

## Problem

The hardcoded runner v2.313.0 was deprecated by GitHub around Feb 28, 2026. EC2 instances boot successfully but fail to register as self-hosted runners because GitHub rejects the outdated version. This caused ~90% of Recording CI runs to fail with:

> A timeout of 5 minutes is exceeded. Your AWS EC2 instance was not able to register itself in GitHub as a new self-hosted runner.

## Changes

- `src/aws.js`: Replaced static version download URL with dynamic version lookup
- `dist/index.js`: Rebuilt bundle

## Test plan

- [ ] After merging, tag a new release (e.g. `v1.1.0`) and update `mmhmm-service` workflow to reference it
- [ ] Verify Recording CI passes with the new runner version
- [ ] Verify the runner version is logged in the EC2 startup output

🤖 Generated with [Claude Code](https://claude.com/claude-code)