### PR TITLE
Upgrade action runtime from node20 to node24

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install packages
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   runuser, tolerant chown, stale config cleanup, and package installation.
 
 ### Changed
+- Upgraded action runtime from `node20` to `node24` to resolve GitHub Actions deprecation warning (Node.js 20 actions deprecated June 2026).
+- Updated `package.yml` workflow to build distribution with Node.js 24.
 - Switched user-data format from `#cloud-config` with `runcmd` to `#cloud-boothook`.
   This fixes compatibility with Amazon Linux 2023 and other AMIs where
   `cloud_final_modules` may be empty or misconfigured.

--- a/action.yml
+++ b/action.yml
@@ -173,5 +173,5 @@ outputs:
       AWS region where the EC2 instance was created.
       This is useful for subsequent AWS operations on the instance.
 runs:
-  using: node20
+  using: node24
   main: ./dist/index.js


### PR DESCRIPTION
## Summary

- Updates `action.yml` runtime from `node20` to `node24`
- Updates `package.yml` workflow to build with Node.js 24
- Adds CHANGELOG entry

## Motivation

GitHub Actions is deprecating Node.js 20 actions with enforcement starting June 2nd, 2026:

> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan

- [x] `npm test` — all 25 tests pass
- [x] `npm run lint` — no issues
- [x] `npm run package` — dist rebuilt successfully with Node.js 24.14.0